### PR TITLE
Comments using Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## Objectives:
 This program takes the hydromechanical properties of a partially saturated 1D soil for a given steady-state condition and computes:
-- (i)   The saturation profile in depth ;
-- (ii)  The variations of Vp, Vs, and rho with saturation (depth) ;    
-- (iii) The P-wave first arrival times and suface-wave dispersion for a given linear acquisition setup.
+1)   The saturation profile in depth ;
+2)  The variations of Vp, Vs, and rho with saturation (depth) ;    
+3) The P-wave first arrival times and suface-wave dispersion for a given linear acquisition setup.
 
 ## Reference
 Solazzi, S. G., Bodet, L., Holliger, K., & Jougnot, D. (2021). Surface-wave dispersion in partially saturated soils: The role of capillary forces. Journal of Geophysical Research: Solid Earth, 126, e2021JB022074. 
@@ -19,35 +19,39 @@ https://doi.org/10.1029/2021JB022074
 -> this code makes it possible to compute figures 5 and 6 (but also the others, if you manage some minor modifs...)
 
 ## Dependencies:
-  Source code is stored in ./src folder.
-  Functions are written in C++ file (*.cpp) and wrapped in Cython file (*.pyx) to be compiled
+  Source code is stored in `./src` folder.
+  Functions are written in C++ file (`*.cpp`) and wrapped in Cython file (`*.pyx`) to be compiled
   as a shared library and called in Python.
-  - Source functions in C++ are named as nameFunction_src
+  - Source functions in C++ are named as `nameFunctionSrc`
   - Wapped functions in Cython to be called in Python are named as nameFunction
-  -> If you change the header of a function in the *.cpp, you must change it on the *.pyx file also.
+  -> If you change the header of a function in the `*.cpp`, you must change it on the `*.pyx` file also.
 
-  ### C++ functions for RP and VG models are stored in ./src/RPfunctions_src.cpp and ./src/GVfunctions_src.cpp:
-      - ./src/GVfunctions_src.cpp/vanGen_src -> to compute Saturation from...
-      - ./src/GVfunctions_src.cpp/hillsAverage_src -> to compute ... from ...
-      - ...
-  ### Seismic data forward modelling utils stored in ./src/TTDSPfunctions_src.cpp :
-      - ./src/TTDSPfunctions_src.cpp/firstArrival_src -> compute P- or S-wave first arrival times from a 1D velocity model
-      + *gpdc* -> code (to be compiled and called) from https://www.geopsy.org 
-          to to compute surface-wave dispersion from a 1D velocity model
-      + I/O functions:
-      - ./src/TTDSPfunctions_src.cpp/dinSave_src -> create 1D velocity models readable by *gpdc*
-      - ./src/TTDSPfunctions_src.cpp/readDisp -> Only function not wtitten in C++ but directly in Cython in the *.pyx file - reads dispersion curves created by *gpdc*
- ### Utils in bash and or latex to plot results ./src folder:
-      - *cropSANTILUDO.sh* (as to be chmod +x...) 
-      - ...
+  ### C++ functions for RP and VG models are stored in ./src/RPfunctions_src.cpp and ./src/GVfunctions_src.cpp:  
+- ./src/VGfunctions_src.cpp/vanGen_src -> to compute Saturation from...
+- ./src/VGfunctions_src.cpp/hillsAverage_src -> to compute ... from ...
+- ...
+  ### Seismic data forward modelling utils stored in ./src/TTDSPfunctions_src.cpp :  
+- ./src/TTDSPfunctions_src.cpp/firstArrival_src -> compute P- or S-wave first arrival times from a 1D velocity model
+- *gpdc* -> code (to be compiled and called) from https://www.geopsy.org 
+          to compute surface-wave dispersion from a 1D velocity model
+- I/O functions:
+    - ./src/TTDSPfunctions_src.cpp/dinSave_src -> create 1D velocity models readable by *gpdc*
+    - ./src/TTDSPfunctions_src.cpp/readDisp -> Only function not written in C++ but directly in Cython in the `*.pyx` file - reads dispersion curves created by *gpdc*
+ ### Utils in bash and or latex to plot results ./src folder:  
+- *cropSANTILUDO.sh* (as to be chmod +x...) 
+- ...
 
 ## Compilation is done with the setup.py file :
+```sh
 python3 setup.py build_ext --inplace clean
-This creates a ./build and ./bib directories, with the last containing the shared libraries *.so
-that can be used in Python and the resulting *.cpp files from the *.pyx compilation
+```
+This creates a `./build` and `./bib` directories, with the last containing the shared libraries `*.so`
+that can be used in Python and the resulting `*.cpp` files from the `*.pyx` compilation
 
 ## Running the main script :
+```sh
 python3 main_SANTILUDO.py
+```
 
 ## Comments:
 This is a quickly written prototype. A lot to do to improve this code :

--- a/main_SANTILUDO.py
+++ b/main_SANTILUDO.py
@@ -183,7 +183,7 @@ for i, layer in enumerate(layers) :
 
 
 
-# Runnung the program for each water table depth
+# Running the program for each water table depth
 for iWT, WT in enumerate(WTs) :
     #### ROCK PHYSICS -------------------------------------------------------------------------------------------------------------------------------
     # Saturation profile with depth

--- a/main_SANTILUDO.py
+++ b/main_SANTILUDO.py
@@ -1,7 +1,7 @@
 """
 PROGRAM SANTILUDO
 - Programmers: *S.G. Solazzi & L. Bodet* (vanGen.m courtesy of D. Jougnot)
-- Frist version: *2020/07/14*
+- First version: *2020/07/14*
 - Last update (first draft with synthetic computation) on 2022/03
 - Some minor modifs 2024/03
 - Converted to C++, and interfaced with Python, on 2024/03 by J. Cunha Teixeira
@@ -26,7 +26,7 @@ https://doi.org/10.1029/2021JB022074
   Source code is stored in ./src folder.
   Functions are written in C++ file (*.cpp) and wrapped in Cython file (*.pyx) to be compiled
   as a shared library and called in Python.
-  - Source functions in C++ are named as nameFunction_src
+  - Source functions in C++ are named as nameFunctionSrc
   - Wapped functions in Cython to be called in Python are named as nameFunction
   -> If you change the header of a function in the *.cpp, you must change it on the *.pyx file also.
 

--- a/src/RPfunctions.pyx
+++ b/src/RPfunctions.pyx
@@ -10,43 +10,43 @@ from libcpp.string cimport string
 # Import the C++ function declaration
 cdef extern from "RPfunctions_src.cpp":
 
-    cdef struct effFluid_Result:
-       vector[double] kf, rhof, rhob
+    cdef struct effFluidResult:
+       vector[double] k_f, rho_f, rho_b
 
-    cdef struct biotGassmann_Result:
-        vector[double] Vp, Vs
+    cdef struct biotGassmannResult:
+        vector[double] v_p, v_s
 
-    cdef struct hertzMindlin_Result:
-        vector[double] KHM, muHM
+    cdef struct hertzMindlinResult:
+        vector[double] k_m, mu_m
 
-    cdef struct hillsAverage_Result:
-        vector[double] mus, ks, rhos, nus
+    cdef struct hillsAverageResult:
+        vector[double] mu_s, k_s, rho_s, nu_s
 
-    effFluid_Result effFluid_src(vector[double] Sw, double kw, double ka, double rhow, double rhoa, vector[double] rhos, vector[string] soiltypes, vector[double] thicknesses, double dz)
-    double fish_src(double vp, double vs)
-    biotGassmann_Result biotGassmann_src(vector[double] KHM, vector[double] muHM, vector[double] ks, vector[double] kf, vector[double] rhob, vector[string] soiltypes, vector[double] thicknesses, double dz)
-    hertzMindlin_Result hertzMindlin_src(vector[double] Swe, vector[double] z, vector[double] h, vector[double] rhob, double g, double rhoa, double rhow, vector[double] Ns, vector[double] mus, vector[double] nus, vector[double] fracs, int kk, vector[string] soiltypes, vector[double] thicknesses)
-    hillsAverage_Result hillsAverage_src(double mu_clay, double mu_silt, double mu_sand, double rho_clay, double rho_silt, double rho_sand, double k_clay, double k_silt, double k_sand, vector[string] soiltypes)
+    effFluidResult effFluidSrc(vector[double] s_w, double k_w, double k_a, double rho_w, double rho_a, vector[double] rho_s, vector[string] soil_types, vector[double] thicknesses, double dz)
+    double fishSrc(double v_p, double v_s)
+    biotGassmannResult biotGassmannSrc(vector[double] k_m, vector[double] mu_m, vector[double] k_s, vector[double] k_f, vector[double] rho_b, vector[string] soil_types, vector[double] thicknesses, double dz)
+    hertzMindlinResult hertzMindlinSrc(vector[double] s_we, vector[double] z, vector[double] h, vector[double] rho_b, double g, double rho_a, double rho_w, vector[double] n_s, vector[double] mu_s, vector[double] nu_s, vector[double] fracs, int kk, vector[string] soil_types, vector[double] thicknesses)
+    hillsAverageResult hillsAverageSrc(double mu_clay, double mu_silt, double mu_sand, double rho_clay, double rho_silt, double rho_sand, double k_clay, double k_silt, double k_sand, vector[string] soil_types)
 
 
 
 # Define Python wrapper functions
-def effFluid(Sw, kw, ka, rhow, rhoa, rhos, soiltypes, thicknesses, dz):
-    cdef effFluid_Result result = effFluid_src(Sw, kw, ka, rhow, rhoa, rhos, soiltypes, thicknesses, dz)
-    return (result.kf, result.rhof, result.rhob)
+def effFluid(s_w, k_w, k_a, rho_w, rho_a, rho_s, soil_types, thicknesses, dz):
+    cdef effFluidResult result = effFluidSrc(s_w, k_w, k_a, rho_w, rho_a, rho_s, soil_types, thicknesses, dz)
+    return (result.k_f, result.rho_f, result.rho_b)
 
-def fish(vp, vs):
-    cdef double sig = fish_src(vp, vs)
+def fish(v_p, v_s):
+    cdef double sig = fishSrc(v_p, v_s)
     return sig
 
-def biotGassmann(KHM, muHM, ks, kf, rhob, soiltypes, thicknesses, dz):
-    cdef biotGassmann_Result result = biotGassmann_src(KHM, muHM, ks, kf, rhob, soiltypes, thicknesses, dz)
-    return (result.Vp, result.Vs)
+def biotGassmann(k_m, mu_m, k_s, k_f, rho_b, soil_types, thicknesses, dz):
+    cdef biotGassmannResult result = biotGassmannSrc(k_m, mu_m, k_s, k_f, rho_b, soil_types, thicknesses, dz)
+    return (result.v_p, result.v_s)
 
-def hertzMindlin(Swe, z, h, rhob, g, rhoa, rhow, Ns, mus, nus, fracs, kk, soiltypes, thicknesses):
-    cdef hertzMindlin_Result result = hertzMindlin_src(Swe, z, h, rhob, g, rhoa, rhow, Ns, mus, nus, fracs, kk, soiltypes, thicknesses)
-    return (result.KHM, result.muHM)
+def hertzMindlin(s_we, z, h, rho_b, g, rho_a, rho_w, n_s, mu_s, nu_s, fracs, kk, soil_types, thicknesses):
+    cdef hertzMindlinResult result = hertzMindlinSrc(s_we, z, h, rho_b, g, rho_a, rho_w, n_s, mu_s, nu_s, fracs, kk, soil_types, thicknesses)
+    return (result.k_m, result.mu_m)
 
-def hillsAverage(mu_clay, mu_silt, mu_sand, rho_clay, rho_silt, rho_sand, k_clay, k_silt, k_sand, soiltypes):
-    cdef hillsAverage_Result result = hillsAverage_src(mu_clay, mu_silt, mu_sand, rho_clay, rho_silt, rho_sand, k_clay, k_silt, k_sand, soiltypes)
-    return (result.mus, result.ks, result.rhos, result.nus)
+def hillsAverage(mu_clay, mu_silt, mu_sand, rho_clay, rho_silt, rho_sand, k_clay, k_silt, k_sand, soil_types):
+    cdef hillsAverageResult result = hillsAverageSrc(mu_clay, mu_silt, mu_sand, rho_clay, rho_silt, rho_sand, k_clay, k_silt, k_sand, soil_types)
+    return (result.mu_s, result.k_s, result.rho_s, result.nu_s)

--- a/src/RPfunctions_src.cpp
+++ b/src/RPfunctions_src.cpp
@@ -4,25 +4,51 @@
 
 
 
-struct effFluid_Result {
-    std::vector<double> kf, rhof, rhob;
+struct effFluidResult {
+    std::vector<double> k_f; // Effective compressibility over depth [Pa^-1]
+    std::vector<double> rho_f; // Effective fluid density over depth [Kg/m3]
+    std::vector<double> rho_b; // Bulk density over depth [Kg/m3]
 };
 
-struct biotGassmann_Result {
-    std::vector<double> Vp, Vs;
+struct biotGassmannResult {
+    std::vector<double> v_p; // P-wave velocity [m/s]
+    std::vector<double> v_s; // S-wave velocity [m/s]
 };
 
-struct hertzMindlin_Result {
-    std::vector<double> KHM, muHM;
+struct hertzMindlinResult {
+    std::vector<double> k_m; // Effective bulk modulus over depth [Pa]
+    std::vector<double> mu_m; // Effective shear modulus over depth [Pa]
 };
 
-struct hillsAverage_Result {
-    std::vector<double> mus, ks, rhos, nus;
+struct hillsAverageResult {
+    std::vector<double> mu_s; // Shear moduli of grain of each layer [Pa]
+    std::vector<double> k_s; // Bulk moduli of grain of each layer [Pa]
+    std::vector<double> rho_s; // Densities of grain of each layer [Kg/m3]
+    std::vector<double> nu_s; // Poisson's ratios of each layer [-]
 };
 
 
-
-hillsAverage_Result hillsAverage_src(const double& mu_clay,
+/**
+ * Computes the effective properties of the solid grains from its constituents for each layer of soil types
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param mu_clay shear modulus of clay [GPa]
+ * @param mu_silt shear modulus of silt [GPa]
+ * @param mu_sand shear modulus of sand [GPa]
+ * @param rho_clay density of clay [Kg/m3]
+ * @param rho_silt density of silt [Kg/m3]
+ * @param rho_sand density of sand [Kg/m3]
+ * @param k_clay bulk modulus of clay [GPa]
+ * @param k_silt bulk modulus of silt [GPa]
+ * @param k_sand bulk modulus of sand [GPa]
+ * @param soil_types soil types of each layer in the profile
+ * @return a hillsAverageResult structure containing the effective properties of the solid grains for each layer of soil types
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+hillsAverageResult hillsAverageSrc(const double& mu_clay,
                                      const double& mu_silt,
                                      const double& mu_sand,
                                      const double& rho_clay,
@@ -31,188 +57,148 @@ hillsAverage_Result hillsAverage_src(const double& mu_clay,
                                      const double& k_clay,
                                      const double& k_silt,
                                      const double& k_sand,
-                                     const std::vector<std::string>& soiltypes) {
-    // ==========================================
-    // Computes the effective properties of the solid grains from its constituents
-    //
-    // Parameters:
-    // double mu_clay: Shear modulus of clay [GPa]
-    // double mu_silt: Shear modulus of silt [GPa]
-    // double mu_sand: Shear modulus of sand [GPa]
-    // double rho_clay: Density of clay [Kg/m3]
-    // double rho_silt: Density of silt [Kg/m3]
-    // double rho_sand: Density of sand [Kg/m3]
-    // double k_clay: Bulk modulus of clay [GPa]
-    // double k_silt: Bulk modulus of silt [GPa]
-    // double k_sand: Bulk modulus of sand [GPa]
-    // vector[string] soiltypes: soil types of each layer in the profile
-    //
-    // Outputs:
-    // hillsAverage_Result result: structure with the following fields
-    // vector [double] mus: Shear moduli of grain of each layer [Pa]
-    // vector[double] ks: Bulk moduli of grain of each layer [Pa]
-    // vector[double] rhos: Densities of grain of each layer [Kg/m3]
-    // vector[double] nus: Poisson's ratios of each layer [-]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
+                                     const std::vector<std::string>& soil_types) {
 
-    std::vector<double> mus(soiltypes.size()); // Shear moduli of grain of each layer
-    std::vector<double> ks(soiltypes.size()); // Bulk moduli of grain of each layer
-    std::vector<double> rhos(soiltypes.size()); // Densities of grain of each layer
-    std::vector<double> nus(soiltypes.size()); // Poisson's ratios of each layer
+    std::vector<double> mu_s(soil_types.size()); // Shear moduli of grain of each layer
+    std::vector<double> k_s(soil_types.size()); // Bulk moduli of grain of each layer
+    std::vector<double> rho_s(soil_types.size()); // Densities of grain of each layer
+    std::vector<double> nu_s(soil_types.size()); // Poisson's ratios of each layer
 
-    for (size_t j = 0; j < soiltypes.size(); ++j) {
-        std::string_view soilType = soiltypes[j]; // Soil type for current layer
+    for (size_t j = 0; j < soil_types.size(); ++j) {
+        std::string_view soil_type = soil_types[j]; // Soil type for current layer
 
-        selectSoilType_Result soil = selectSoilType_src(soilType); // Soil properties for current layer
+        soilType soil = selectSoilTypeSrc(soil_type); // Soil properties for current layer
 
         // Shear moduli of grain [Pa]
-        mus[j] = 0.5 * (1 / (soil.wclay / mu_clay + soil.wsilt / mu_silt + soil.wsand / mu_sand) + (soil.wclay * mu_clay + soil.wsilt * mu_silt + soil.wsand * mu_sand)) * 1e9;
+        mu_s[j] = 0.5 * (1 / (soil.wclay / mu_clay + soil.wsilt / mu_silt + soil.wsand / mu_sand) + (soil.wclay * mu_clay + soil.wsilt * mu_silt + soil.wsand * mu_sand)) * 1e9;
         
         // Bulk moduli of grain [Pa]
-        ks[j] = 0.5 * (1 / (soil.wclay / k_clay + soil.wsilt / k_silt + soil.wsand / k_sand) + (soil.wclay * k_clay + soil.wsilt * k_silt + soil.wsand * k_sand)) * 1e9;
+        k_s[j] = 0.5 * (1 / (soil.wclay / k_clay + soil.wsilt / k_silt + soil.wsand / k_sand) + (soil.wclay * k_clay + soil.wsilt * k_silt + soil.wsand * k_sand)) * 1e9;
         
         // Densities of grain [Kg/m3]
-        rhos[j] = soil.wclay * rho_clay + soil.wsilt * rho_silt + soil.wsand * rho_sand;
+        rho_s[j] = soil.wclay * rho_clay + soil.wsilt * rho_silt + soil.wsand * rho_sand;
         
         // Poisson's ratios
-        nus[j] = (3 * ks[j] - 2 * mus[j]) / (2 * (3 * ks[j] + mus[j]));
+        nu_s[j] = (3 * k_s[j] - 2 * mu_s[j]) / (2 * (3 * k_s[j] + mu_s[j]));
     }
 
-    hillsAverage_Result result; // Structure to store the results
-    result.mus = mus;
-    result.ks = ks;
-    result.rhos = rhos;
-    result.nus = nus;
+    hillsAverageResult result; // Structure to store the results
+    result.mu_s = mu_s;
+    result.k_s = k_s;
+    result.rho_s = rho_s;
+    result.nu_s = nu_s;
 
     return result;
 }
 
 
-
-effFluid_Result effFluid_src(const std::vector<double>& Sws,
+/**
+ * Computes effective fluid properties and bulk density for each layer of soil type
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param s_ws total saturation over depth [-]
+ * @param kw water bulk modulus [Pa]
+ * @param ka air bulk modulus [Pa]
+ * @param rho_w water density [Kg/m3]
+ * @param rho_a air density [Kg/m3]
+ * @param rho_s Densities of grain of each layer [Kg/m3]
+ * @param soil_types Soil types of each layer in the profile
+ * @param thiknesses thickness of each layer [m]
+ * @param dz depth discretization [m]
+ * @return a effFluidResult structure containing the effective properties and bulk density for each layer of soil type
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+effFluidResult effFluidSrc(const std::vector<double>& s_ws,
                              const double& kw,
                              const double& ka,
-                             const double& rhow,
-                             const double& rhoa,
-                             const std::vector<double>& rhos,
-                             const std::vector<std::string>& soiltypes,
+                             const double& rho_w,
+                             const double& rho_a,
+                             const std::vector<double>& rho_s,
+                             const std::vector<std::string>& soil_types,
                              const std::vector<double>& thicknesses,
                              const double& dz) {
-    // ==========================================
-    // Computes effective fluid properties and bulk density
-    //
-    // Parameters:
-    // vector[double] Sws: total saturation over depth [-]
-    // double kw: water bulk modulus [Pa]
-    // double ka: air bulk modulus [Pa]
-    // double rhow: water density [Kg/m3]
-    // double rhoa: air density [Kg/m3]
-    // vector[double] rhos: Densities of grain of each layer [Kg/m3]
-    // vector[string] soiltypes: soil types of each layer in the profile
-    // vector[double] thicknesses: thickness of each layer [m]
-    // double dz: depth discretization [m]
-    //
-    // Outputs:
-    // effFluid_Result result: structure with the following fields
-    // vector [double] kf: effective compressibility over depth [Pa-1]
-    // vector[double] rhof: effective fluid density over depth [Kg/m3]
-    // vector[double] rhob: bulk density over depth [Kg/m3]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
 
-    size_t num_points = Sws.size(); // Number of cells in the profile
+    size_t num_points = s_ws.size(); // Number of cells in the profile
 
-    std::vector<double> kf(num_points); // Effective compressibility over depth
-    std::vector<double> rhof(num_points); // Effective fluid density over depth
-    std::vector<double> rhob(num_points); // Bulk density over depth
+    std::vector<double> k_f(num_points); // Effective compressibility over depth
+    std::vector<double> rho_f(num_points); // Effective fluid density over depth
+    std::vector<double> rho_b(num_points); // Bulk density over depth
 
     int start = 0; // Depth start index for fisrt layer
 
-    for (size_t j = 0; j < soiltypes.size(); ++j) {
-        std::string_view soilType = soiltypes[j]; // Soil type for current layer
+    for (size_t j = 0; j < soil_types.size(); ++j) {
+        std::string_view soil_type = soil_types[j]; // Soil type for current layer
         double thickness = thicknesses[j]; // Thickness of current layer
 
-        selectSoilType_Result soil = selectSoilType_src(soilType); // Soil properties for current layer
+        soilType soil = selectSoilTypeSrc(soil_type); // Soil properties for current layer
 
         int end = round(thickness / dz) + start; // Depth end index for current layer
 
         for (int i = start; i < end; ++i) {
-            kf[i] = 1.0 / (Sws[i] / kw + (1.0 - Sws[i]) / ka); // Effective compressibility (Woods formula)
-            rhof[i] = Sws[i] * rhow + (1.0 - Sws[i]) * rhoa; // Effective fluid density
-            rhob[i] = (1.0 - soil.phi) * rhos[j] + soil.phi * rhof[i]; // Bulk density
+            k_f[i] = 1.0 / (s_ws[i] / kw + (1.0 - s_ws[i]) / ka); // Effective compressibility (Woods formula)
+            rho_f[i] = s_ws[i] * rho_w + (1.0 - s_ws[i]) * rho_a; // Effective fluid density
+            rho_b[i] = (1.0 - soil.phi) * rho_s[j] + soil.phi * rho_f[i]; // Bulk density
         }
         start = end; // Update start index for next layer
     }
 
-    effFluid_Result result; // Structure to store the results
-    result.kf = kf;
-    result.rhof = rhof;
-    result.rhob = rhob;
+    effFluidResult result; // Structure to store the results
+    result.k_f = k_f;
+    result.rho_f = rho_f;
+    result.rho_b = rho_b;
 
     return result;
 }
 
 
-
-hertzMindlin_Result hertzMindlin_src(const std::vector<double>& Swe,
+/**
+ * Computes the effective properties for each layer of soil type using the Hertz Mindlin model
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param s_we effective wetting phase saturation over depth [-]
+ * @param z depths of the profile [m]
+ * @param h pressure head over depth [m]
+ * @param rho_b bulk density over depth [Kg/m3]
+ * @param g gravity [m/s2]
+ * @param rho_a air density [Kg/m3]
+ * @param rho_w water density [Kg/m3]
+ * @param n_s coordination number of each layer [-]
+ * @param mu_s shear moduli of grain of each layer [GPa]
+ * @param nu_s Poisson's ratios of each layer [-]
+ * @param fracs fraction of non-slipping grains of each layer [-]
+ * @param kk type of effective stress
+ * @param soil_types soil types of each layer in the profile
+ * @param thicknesses thickness of each layer [m]
+ * @return a hertzMindlinResult structure containing the effective properties of each layer of soil type
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+hertzMindlinResult hertzMindlinSrc(const std::vector<double>& s_we,
                                      const std::vector<double>& z,
                                      const std::vector<double>& h,
-                                     const std::vector<double>& rhob,
+                                     const std::vector<double>& rho_b,
                                      const double& g,
-                                     const double& rhoa,
-                                     const double& rhow,
-                                     const std::vector<double>& Ns,
-                                     const std::vector<double>& mus,
-                                     const std::vector<double>& nus,
+                                     const double& rho_a,
+                                     const double& rho_w,
+                                     const std::vector<double>& n_s,
+                                     const std::vector<double>& mu_s,
+                                     const std::vector<double>& nu_s,
                                      const std::vector<double>& fracs,
                                      const int& kk,
-                                     const std::vector<std::string>& soiltypes,
+                                     const std::vector<std::string>& soil_types,
                                      const std::vector<double>& thicknesses) {
-    // ==========================================
-    // Hertz-Mindlin model
-    //
-    // Parameters:
-    // vector[double] Swe: effective wetting phase saturation over depth [-]
-    // vector[double] z: depths of the profile [m]
-    // vector[double] h: pressure head over depth [m]
-    // vector[double] rhob: bulk density over depth [Kg/m3]
-    // double g: gravity [m/s2]
-    // double rhoa: air density [Kg/m3]
-    // double rhow: water density [Kg/m3]
-    // vector[double] Ns: coordination number of each layer [-]
-    // vector[double] mus: Shear moduli of grain of each layer [GPa]
-    // vector[double] nus: Poisson's ratios of each layer [-]
-    // vector[double] fracs: fraction of non-slipping grains of each layer [-]
-    // int kk: type of effective stress
-    // vector[string] soiltypes: soil types of each layer in the profile
-    // vector[double] thicknesses: thickness of each layer [m]
-    //
-    // Outputs:
-    // hertzMindlin_Result result: structure with the following fields
-    // vector [double] KHM: effective bulk modulus over depth [Pa]
-    // vector[double] muHM: effective shear modulus over depth [Pa]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
 
-    size_t num_points = Swe.size(); // Number of cells in the profile
+    size_t num_points = s_we.size(); // Number of cells in the profile
 
-    std::vector<double> KHM(num_points); // Effective bulk modulus over depth
-    std::vector<double> muHM(num_points); // Effective shear modulus over depth
+    std::vector<double> k_m(num_points); // Effective bulk modulus over depth
+    std::vector<double> mu_m(num_points); // Effective shear modulus over depth
     
-    std::vector<double> Pe(num_points); // Overburden stress over depth
+    std::vector<double> pe(num_points); // Overburden stress over depth
 
     double dz = fabs(z[1] - z[0]); // Depth discretization
 
@@ -220,134 +206,123 @@ hertzMindlin_Result hertzMindlin_src(const std::vector<double>& Swe,
 
     double sigma_prev = 0; // Previous overburden stress
 
-    for (size_t j = 0; j < soiltypes.size(); ++j) {
-        std::string_view soilType = soiltypes[j]; // Soil type for current layer
+    for (size_t j = 0; j < soil_types.size(); ++j) {
+        std::string_view soil_type = soil_types[j]; // Soil type for current layer
         double thickness = thicknesses[j]; // Thickness of current layer
 
-        selectSoilType_Result soil = selectSoilType_src(soilType); // Soil properties for current layer
+        soilType soil = selectSoilTypeSrc(soil_type); // Soil properties for current layer
 
         int end = round(thickness / dz) + start; // Depth end index for current layer
 
         for (int i = start; i < end; ++i) {
 
-            double sigma = rhob[i] * g * dz + sigma_prev; // Overburden stress
+            double sigma = rho_b[i] * g * dz + sigma_prev; // Overburden stress
             sigma_prev = sigma;
 
             double dep = fabs(z[i]); // Depth (positive value)
-            double St = (h[i] <= 0) ? 0 : Swe[i] * rhow * g * h[i]; // Suction term | Null when fully saturated
-            double Pa = rhoa * g * dep; // Air pressure
-            double Pe; // Effective stress
-            
+            double st = (h[i] <= 0) ? 0 : s_we[i] * rho_w * g * h[i]; // Suction term | Null when fully saturated
+            double pa = rho_a * g * dep; // Air pressure
+            double pe; // Effective stress
+
             if (kk == 1) {
-                Pe = 101325;
+                pe = 101325;
             } else if (kk == 2) {
-                Pe = sigma - Pa;
+                pe = sigma - pa;
             } else if (kk == 3) {
-                Pe = sigma - Pa + St;
+                pe = sigma - pa + st;
             } else {
                 throw std::invalid_argument("Invalid value for kk");
             }
 
-            KHM[i] = std::pow((Ns[j]*Ns[j] * std::pow((1 - soil.phi), 2) * mus[j]*mus[j] * Pe) / (18 * M_PI*M_PI * std::pow((1 - nus[j]), 2)), 1.0 / 3.0); // Effective bulk modulus
-            muHM[i] = ((2 + 3 * fracs[j] - (1 + 3 * fracs[j]) * nus[j]) / (5 * (2 - nus[j]))) * std::pow((3 * Ns[j]*Ns[j] * std::pow((1 - soil.phi), 2) * mus[j]*mus[j] * Pe) / (2 * M_PI*M_PI * std::pow((1 - nus[j]), 2)), 1.0 / 3.0); // Effective shear modulus
+            k_m[i] = std::pow((n_s[j]*n_s[j] * std::pow((1 - soil.phi), 2) * mu_s[j]*mu_s[j] * pe) / (18 * M_PI*M_PI * std::pow((1 - nu_s[j]), 2)), 1.0 / 3.0); // Effective bulk modulus
+            mu_m[i] = ((2 + 3 * fracs[j] - (1 + 3 * fracs[j]) * nu_s[j]) / (5 * (2 - nu_s[j]))) * std::pow((3 * n_s[j]*n_s[j] * std::pow((1 - soil.phi), 2) * mu_s[j]*mu_s[j] * pe) / (2 * M_PI*M_PI * std::pow((1 - nu_s[j]), 2)), 1.0 / 3.0); // Effective shear modulus
         }
         start = end; // Update start index for next layer
     }
 
-    hertzMindlin_Result result; // Structure to store the results
-    result.KHM = KHM;
-    result.muHM = muHM;
+    hertzMindlinResult result; // Structure to store the results
+    result.k_m = k_m;
+    result.mu_m = mu_m;
     
     return result;
 }
 
 
-
-biotGassmann_Result biotGassmann_src(const std::vector<double>& KHM,
-                                     const std::vector<double>& muHM,
-                                     const std::vector<double>& ks,
-                                     const std::vector<double>& kf,
-                                     const std::vector<double>& rhob,
-                                     const std::vector<std::string>& soiltypes,
+/**
+ * Computes the P- and S-wave velocity for each layer of soil type using the Biot Gassmann model
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param k_m effective bulk modulus over depth [Pa]
+ * @param mu_m effective shear modulus over depth [Pa]
+ * @param k_s bulk moduli of grain of each layer [Pa]
+ * @param k_f effective compressibility over depth [Pa^-1]
+ * @param rho_b bulk density over depth [Kg/m3]
+ * @param soil_types soil types of each layer in the profile
+ * @param thicknesses thickness of each layer [m]
+ * @param dz depth discretization [m]
+ * @return a biotGassmannResult structure containing the effective properties of each layer of soil type
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+biotGassmannResult biotGassmannSrc(const std::vector<double>& k_m,
+                                     const std::vector<double>& mu_m,
+                                     const std::vector<double>& k_s,
+                                     const std::vector<double>& k_f,
+                                     const std::vector<double>& rho_b,
+                                     const std::vector<std::string>& soil_types,
                                      const std::vector<double>& thicknesses,
                                      const double& dz) {
-    // ==========================================
-    // Biot Gassman equations
-    //
-    // Parameters:
-    // vector[double] KHM: effective bulk modulus over depth [Pa]
-    // vector[double] muHM: effective shear modulus over depth [Pa]
-    // vector[double] ks: Bulk moduli of grain of each layer [Pa]
-    // vector[double] kf: effective compressibility over depth [Pa-1]
-    // vector[double] rhob: bulk density over depth [Kg/m3]
-    // vector[string] soiltypes: soil types of each layer in the profile
-    // vector[double] thicknesses: thickness of each layer [m]
-    // double dz: depth discretization [m]
-    //
-    // Outputs:
-    // biotGassmann_Result result: structure with the following fields
-    // vector [double] Vp: P-wave velocity over depth [m/s]
-    // vector[double] Vs: S-wave velocity over depth [m/s]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
 
-    size_t num_points = KHM.size(); // Number of cells in the profile
+    size_t num_points = k_m.size(); // Number of cells in the profile
 
-    std::vector<double> Vp(num_points); // P-wave velocity over depth
-    std::vector<double> Vs(num_points); // S-wave velocity over depth
+    std::vector<double> v_p(num_points); // P-wave velocity over depth
+    std::vector<double> v_s(num_points); // S-wave velocity over depth
 
     int start = 0; // Depth start index for fisrt layer
 
-    for (size_t j = 0; j < soiltypes.size(); ++j) {
-        std::string_view soilType = soiltypes[j]; // Soil type for current layer
+    for (size_t j = 0; j < soil_types.size(); ++j) {
+        std::string_view soil_type = soil_types[j]; // Soil type for current layer
         double thickness = thicknesses[j]; // Thickness of current layer
 
-        selectSoilType_Result soil = selectSoilType_src(soilType); // Soil properties for current layer
+        soilType soil = selectSoilTypeSrc(soil_type); // Soil properties for current layer
 
         int end = round(thickness / dz) + start; // Depth end index for current layer
 
         for (int i = start; i < end; ++i) {
-            double alpha2, K;
-            alpha2 = 1 - KHM[i] / ks[j];
-            K = KHM[i] + (alpha2 * alpha2) / (soil.phi / kf[i] + (1 - soil.phi) / ks[j] - KHM[i] / (ks[j] * ks[j]));
+            double alpha2, k;
+            alpha2 = 1 - k_m[i] / k_s[j];
+            k = k_m[i] + (alpha2 * alpha2) / (soil.phi / k_f[i] + (1 - soil.phi) / k_s[j] - k_m[i] / (k_s[j] * k_s[j]));
 
-            Vp[i] = sqrt((K + (4.0 / 3.0) * muHM[i]) / rhob[i]); // P-wave velocity
-            Vs[i] = sqrt(muHM[i] / rhob[i]); // S-wave velocity
+            v_p[i] = sqrt((k + (4.0 / 3.0) * mu_m[i]) / rho_b[i]); // P-wave velocity
+            v_s[i] = sqrt(mu_m[i] / rho_b[i]); // S-wave velocity
         }
         start = end; // Update start index for next layer
     }
 
-    biotGassmann_Result result; // Structure to store the results
-    result.Vp = Vp;
-    result.Vs = Vs;
+    biotGassmannResult result; // Structure to store the results
+    result.v_p = v_p;
+    result.v_s = v_s;
 
     return result;
 }
 
 
-
-double fish_src(double vp, double vs) {
-    // ==========================================
-    // Poisson's ration from Vp and Vs
-    //
-    // Parameters:
-    // double vp: P-wave velocity [m/s]
-    // double vs: S-wave velocity [m/s]
-    //
-    // Outputs:
-    // double result: Poisson's ratio [-]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
-
-    double ratio = vp/vs;
-    // return (vp*vp - 2*vs*vs) / (2 * (vp*vp - vs*vs))
+/**
+ * Computes Poisson's ratio from v_p and v_s
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param v_p P-wave velocity [m/s]
+ * @param v_s S-wave velocity [m/s]
+ * @return the Poisson's ratio from v_p and v_s
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+double fishSrc(double v_p, double v_s) {
+    double ratio = v_p/v_s;
+    // return (v_p*v_p - 2*v_s*v_s) / (2 * (v_p*v_p - v_s*v_s))
     return (0.5 * ratio*ratio - 1) / (ratio*ratio - 1);
 }

--- a/src/TTDSPfunctions.pyx
+++ b/src/TTDSPfunctions.pyx
@@ -11,20 +11,19 @@ import numpy as np
 
 # Import the C++ function declaration
 cdef extern from "TTDSPfunctions_src.cpp":
-    string writeVelocityModel_src(vector[double] thk, vector[double] vp, vector[double] vs,  vector[double] rho, string substratum, int n_layers_substratum)
-    vector[double] firstArrival_src(vector[double] thk, vector[double] vv, vector[double] Xdata, double trig)
-    
+    string writeVelocityModelSrc(vector[double] thk, vector[double] v_p, vector[double] v_s,  vector[double] rho, string substratum, int n_layers_substratum)
+    vector[double] firstArrivalSrc(vector[double] thk, vector[double] vv, vector[double] Xdata, double trig)
 
 # Define Python wrapper functions
-def writeVelocityModel(thk, vp, vs, rho, substratum, n_layers_substratum):
-    cdef string velocity_model = writeVelocityModel_src(thk, vp, vs, rho, substratum, n_layers_substratum)
+def writeVelocityModel(thk, v_p, v_s, rho, substratum, n_layers_substratum):
+    cdef string velocity_model = writeVelocityModelSrc(thk, v_p, v_s, rho, substratum, n_layers_substratum)
     return velocity_model
 
 def firstArrival(thk, vv, Xdata, trig):
     cdef vector[double] thk_cpp = thk
     cdef vector[double] vv_cpp = vv
     cdef vector[double] Xdata_cpp = Xdata
-    cdef vector[double] result = firstArrival_src(thk_cpp, vv_cpp, Xdata_cpp, trig)
+    cdef vector[double] result = firstArrivalSrc(thk_cpp, vv_cpp, Xdata_cpp, trig)
     Thod = np.array(result)
     return Thod
 

--- a/src/TTDSPfunctions_src.cpp
+++ b/src/TTDSPfunctions_src.cpp
@@ -5,31 +5,27 @@
 #include <algorithm>
 
 
-
-std::string writeVelocityModel_src(const std::vector<double>& thk,
-                        const std::vector<double>& vp,
-                        const std::vector<double>& vs,
+/**
+ * Returns a string of the velocity model in a format expected by GPDC
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param thk thickness of each layer [m]
+ * @param v_p P-wave velocity of each layer [m/s]
+ * @param v_s S-wave velocity of each layer [m/s]
+ * @param rho density of each layer [kg/m^3]
+ * @param under_layers layers to put under the studied soil column on the velocity model in GPDC format
+ * @param n_under_layers number of layers in the under_layers
+ * @return a string of the velocity model in a format expected by GPDC
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+std::string writeVelocityModelSrc(const std::vector<double>& thk,
+                        const std::vector<double>& v_p,
+                        const std::vector<double>& v_s,
                         const std::vector<double>& rho,
                         const std::string_view& under_layers,
                         const int& n_under_layers) {
-    // ==========================================
-    // Returns a string of the velocity model in a format expected by GPDC
-    //
-    // Parameters:
-    // vector<double> thk: thickness of each layer [m]
-    // vector<double> vp: P-wave velocity of each layer [m/s]
-    // vector<double> vs: S-wave velocity of each layer [m/s]
-    // vector<double> rho: density of each layer [kg/m^3]
-    // string under_layers: Layers to put under the studied soil column on the velocity model in GPDC format
-    // int n_under_layers: Number of layers in the under_layers
-    //
-    // Outputs:
-    // string velocity_model: velocity model in GPDC format
-    //
-    // Programmers:
-    // Firstly implemented in Matlab by S. Pasquet in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // ==========================================
 
     int nl = thk.size(); // Number of layers
     std::stringstream velocity_model; // String to store the velocity model
@@ -42,7 +38,7 @@ std::string writeVelocityModel_src(const std::vector<double>& thk,
         } else {
             velocity_model << thk[i] << ' ';
         }
-        velocity_model << vp[i] << ' ' << vs[i] << ' ' << rho[i] << '\n';
+        velocity_model << v_p[i] << ' ' << v_s[i] << ' ' << rho[i] << '\n';
     }
 
     // Write the under_layers
@@ -54,28 +50,24 @@ std::string writeVelocityModel_src(const std::vector<double>& thk,
 }
 
 
-
-std::vector<double> firstArrival_src(const std::vector<double>& thk,
+/**
+ * Computes S- or P-wave first arrival
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeira
+ * @param thk thickness of each layer [m]
+ * @param vv velocity of each layer [m/s]
+ * @param Xdata distance from the source to the receiver [m]
+ * @param trig trigger time [s]
+ * @return hodochrone table
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+std::vector<double> firstArrivalSrc(const std::vector<double>& thk,
                                      const std::vector<double>& vv,
                                      const std::vector<double>& Xdata,
                                      const double& trig) {
-    // ==========================================
-    // Computes S- or P-wave first arrivals
-    //
-    // Parameters:
-    // vector<double> thk: thickness of each layer [m]
-    // vector<double> vv: velocity of each layer [m/s]
-    // vector<double> Xdata: distance from the source to the receiver [m]
-    // double trig: trigger time [s]
-    //
-    // Outputs:
-    // vector<double> Thod: hodochrone table
-    //
-    // Programmers:
-    // Firstly implemented in Matlab by L. Bodet in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // ==========================================
-
+    
     size_t rows = thk.size();
     size_t cols = Xdata.size();
     std::vector<double> Tr(rows*cols, 0.0); // arrival time table as a flatten array

--- a/src/VGfunctions.pyx
+++ b/src/VGfunctions.pyx
@@ -11,22 +11,22 @@ from libcpp.string cimport string
 # Import the C++ function declaration
 cdef extern from "VGfunctions_src.cpp":
 
-    struct vanGen_Result:
-        vector[double] h, Sw, Swe
+    struct vanGenResult:
+        vector[double] h, s_w, s_we
 
-    struct selectSoilType_Result:
-        double wsand, wclay, wsilt, phi, alpha, nvg, theta, Swr
+    struct soilType:
+        double wsand, wclay, wsilt, phi, alpha, nvg, theta, s_wr
 
-    vanGen_Result vanGen_src(vector[double] z, double WT, vector[string] soiltypes, vector[double] thicknesses)
-    selectSoilType_Result selectSoilType_src(string soiltype)
+    vanGenResult vanGenSrc(vector[double] z, double wt, vector[string] soil_types, vector[double] thicknesses)
+    soilType selectSoilTypeSrc(string soil_type)
 
 
 
 # Define Python wrapper functions
-def vanGen(vector[double] z, double WT, vector[string] soiltypes, vector[double] thicknesses):
-    cdef vanGen_Result result = vanGen_src(z, WT, soiltypes, thicknesses)
-    return result.h, result.Sw, result.Swe
+def vanGen(vector[double] z, double wt, vector[string] soil_types, vector[double] thicknesses):
+    cdef vanGenResult result = vanGenSrc(z, wt, soil_types, thicknesses)
+    return result.h, result.s_w, result.s_we
 
-def selectSoilType(string soiltype):
-    cdef selectSoilType_Result result = selectSoilType_src(soiltype)
-    return result.wsand, result.wclay, result.wsilt, result.phi, result.alpha, result.nvg, result.theta, result.Swr 
+def selectSoilType(string soil_type):
+    cdef soilType result = selectSoilTypeSrc(soil_type)
+    return result.wsand, result.wclay, result.wsilt, result.phi, result.alpha, result.nvg, result.theta, result.s_wr 

--- a/src/VGfunctions_src.cpp
+++ b/src/VGfunctions_src.cpp
@@ -5,46 +5,44 @@
 
 
 
-struct vanGen_Result{
-    std::vector<double> h, Sw, Swe;
+struct vanGenResult{
+    std::vector<double> h; // pressure head over depth [m]
+    std::vector<double> s_w; // total saturation over depth [-]
+    std::vector<double> s_we; // effective wetting phase saturation over depth [-]
 };
 
-struct selectSoilType_Result{
-    double wsand, wclay, wsilt, phi, alpha, nvg, theta, Swr;
+struct soilType{
+    double wsand; // sand ratio [-]
+    double wclay; // clay ratio [-]
+    double wsilt; // silt ratio [-]
+    double phi; // soil porosity [-]
+    double alpha; // inverse of entry pressure [1/m]
+    double nvg; // Van Genuchten parameter [-]
+    double theta; // Van Genuchten parameter [-]
+    double s_wr; // residual water saturation [-]
 };
 
 
 
-selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
-    // ==========================================
-    // Based on:
-    // - Carsel, R. F., & Parrish, R. S. (1988). 
-    //     Developing joint probability distributions of soil water retention 
-    //     characteristics. Water Resource Research, 24(5), 755–769.
-    //     https://doi.org/10.1029/wr024i005p00755
-    //
-    // Parameters:
-    // string soiltype: Soil type
-    //
-    // Outputs:
-    // selectSoilType_Result soil: structure with the following fields
-    // double wsand: sand ratio [-]
-    // double wclay: clay ratio [-]
-    // double wsilt: silt ratio [-]
-    // double phi: soil porosity [-]
-    // double alpha: inverse of entry pressure [1/m]
-    // double nvg: Van Genuchten parameter [-]
-    // double theta: Van Genuchten parameter [-]
-    // double Swr: residual water saturation [-]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // ==========================================
+/**
+ * Set the correct parameters values to a soilType for a given soil_type name
+ * Based on:
+ * - Carsel, R. F., & Parrish, R. S. (1988). 
+ *      Developing joint probability distributions of soil water retention 
+ *      characteristics. Water Resource Research, 24(5), 755–769.
+ *      https://doi.org/10.1029/wr024i005p00755
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeir
+ * @param soil_type soil type name
+ * @return a selectSoilTypeResult structure containing the properties of the given soil type
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+soilType selectSoilTypeSrc(const std::string_view& soil_type) {
+    soilType soil; // Structure to store the results
 
-    selectSoilType_Result soil; // Structure to store the results
-
-    if (soiltype == "clay") {
+    if (soil_type == "clay") {
         soil.wsand = 0.149;
         soil.wclay = 0.552;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -52,8 +50,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 0.8;
         soil.nvg = 1.09;
         soil.theta = 0.068;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "silt") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "silt") {
         soil.wsand = 0.058;
         soil.wclay = 0.095;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -61,8 +59,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 1.6;
         soil.nvg = 1.37;
         soil.theta = 0.034;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "clayloam") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "clayloam") {
         soil.wsand = 0.298;
         soil.wclay = 0.326;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -70,8 +68,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 1.9;
         soil.nvg = 1.31;
         soil.theta = 0.095;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "loam") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "loam") {
         soil.wsand = 0.4;
         soil.wclay = 0.197;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -79,8 +77,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 3.6;
         soil.nvg = 1.56;
         soil.theta = 0.078;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "loamysand") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "loamysand") {
         soil.wsand = 0.809;
         soil.wclay = 0.064;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -88,8 +86,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 12.4;
         soil.nvg = 1.28;
         soil.theta = 0.057;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "cleansand") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "cleansand") {
         soil.wsand = 1;
         soil.wclay = 0;
         soil.wsilt = 0;
@@ -97,8 +95,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 14.5;
         soil.nvg = 2.68;
         soil.theta = 0.045;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "sand") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "sand") {
         soil.wsand = 0.927;
         soil.wclay = 0.029;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -106,8 +104,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 14.5;
         soil.nvg = 2.68;
         soil.theta = 0.045;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "sandyclay") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "sandyclay") {
         soil.wsand = 0.52;
         soil.wclay = 0.43;
         soil.wsilt = 0.05;
@@ -115,8 +113,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 2.7;
         soil.nvg = 1.23;
         soil.theta = 0.1;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "sandyclayloam") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "sandyclayloam") {
         soil.wsand = 0.543;
         soil.wclay = 0.274;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -124,8 +122,8 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 1.0;
         soil.nvg = 1.23;
         soil.theta = 0.089;
-        soil.Swr = soil.theta / soil.phi;    }
-    else if (soiltype == "sandyloam") {
+        soil.s_wr = soil.theta / soil.phi;    }
+    else if (soil_type == "sandyloam") {
         soil.wsand = 0.634;
         soil.wclay = 0.111;
         soil.wsilt = 1 - soil.wsand - soil.wclay;
@@ -133,7 +131,7 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
         soil.alpha = 7.5;
         soil.nvg = 1.89;
         soil.theta = 0.065;
-        soil.Swr = soil.theta / soil.phi;    }
+        soil.s_wr = soil.theta / soil.phi;    }
     else {
         throw std::invalid_argument("Invalid soiltype");
     }
@@ -142,63 +140,55 @@ selectSoilType_Result selectSoilType_src(const std::string_view& soiltype) {
 }
 
 
-
-vanGen_Result vanGen_src(const std::vector<double>& z,
-                         const double& WT,
-                         const std::vector<std::string>& soiltypes,
+/**
+ * Computes for each layer of soil type the properties of the soil using the van Genuchten model
+ * 
+ * @author S.G. Solazzi
+ * @author J. Cunha Teixeir
+ * @param z depths of the profile [m]
+ * @param wt depth of the water table [m]
+ * @param soil_types soil types of each layer in the profile
+ * @param thicknesses thickness of each layer [m]
+ * @return a vanGenResult structure containing the properties of each layer of soil type
+*/
+// 2021 - Solazzi - Implemented in Matlab
+// MAR2024 - Cunha Teixeira - Traduced in C++
+// APR2024 - Cunha Teixeira - Adapted for mutli-layers
+vanGenResult vanGenSrc(const std::vector<double>& z,
+                         const double& wt,
+                         const std::vector<std::string>& soil_types,
                          const std::vector<double>& thicknesses) {
-    // ==========================================
-    // Water distribution 
-    // Static conditions
-    //
-    // Parameters:
-    // vector[double] z: depths of the profile [m]
-    // double WT: depth of the water table [m]
-    // vector[string] soiltypes: soil types of each layer in the profile
-    // vector[double] thicknesses: thickness of each layer [m]
-    //
-    // Outputs:
-    // vanGen_Result result: structure with the following fields
-    // vector [double] h: pressure head over depth [m]
-    // vector[double] Sw: total saturation over depth [-]
-    // vector[double] Swe: effective wetting phase saturation over depth [-]
-    //
-    // Programmers:
-    // Firstly implemented in Matlab by D. Jugnot in Solazzi et al. (2021)
-    // Traduced in C++ by J. Cunha Teixeira in 2024/03
-    // Adaptated for multi-layers by J. Cunha Teixeira in 2024/04
-    // ==========================================
 
-    size_t num_points = z.size(); // Number of cells in the profile
+    size_t numPoints = z.size(); // Number of cells in the profile
     double dz = std::abs(z[1] - z[0]); // Depth discretization
 
-    std::vector<double> h(num_points); // Pressure head over depth
-    std::vector<double> Swe(num_points); // Effective wetting phase saturation over depth
-    std::vector<double> Sw(num_points); // Total saturation over depth
+    std::vector<double> h(numPoints); // Pressure head over depth
+    std::vector<double> s_we(numPoints); // Effective wetting phase saturation over depth
+    std::vector<double> s_w(numPoints); // Total saturation over depth
 
     int start = 0; // Depth start index for fisrt layer
 
-    for (size_t j = 0; j < soiltypes.size(); ++j) {
-        std::string_view soilType = soiltypes[j]; // Soil type for current layer
+    for (size_t j = 0; j < soil_types.size(); ++j) {
+        std::string_view soil_type = soil_types[j]; // Soil type for current layer
         double thickness = thicknesses[j]; // Thickness of current layer
         
         int end = round(thickness / dz) + start; // Depth end index for current layer
 
-        selectSoilType_Result soil = selectSoilType_src(soilType); // Soil properties for current layer
+        soilType soil = selectSoilTypeSrc(soil_type); // Soil properties for current layer
         double m = 1.0 - 1.0/soil.nvg; // Parameters related to the pore size distribution (Carsel & Parrish, 1988)
 
         for (int i = start; i < end; ++i) {
-            h[i] = z[i] + WT;
-            Swe[i] = (h[i] <= 0) ? 1 : std::pow(1 + std::pow(soil.alpha * h[i], soil.nvg), -m);
-            Sw[i] = Swe[i] * (1 - soil.Swr) + soil.Swr;
+            h[i] = z[i] + wt;
+            s_we[i] = (h[i] <= 0) ? 1 : std::pow(1 + std::pow(soil.alpha * h[i], soil.nvg), -m);
+            s_w[i] = s_we[i] * (1 - soil.s_wr) + soil.s_wr;
         }
         start = end; // Update start index for next layer
     }
 
-    vanGen_Result result; // Structure to store the results
+    vanGenResult result; // Structure to store the results
     result.h = h;
-    result.Sw = Sw;
-    result.Swe = Swe;
+    result.s_w = s_w;
+    result.s_we = s_we;
 
     return result;
 }

--- a/src/VGfunctions_src.h
+++ b/src/VGfunctions_src.h
@@ -5,17 +5,17 @@
 #include <vector>
 #include <string>
 
-struct vanGen_Result {
-    std::vector<double> h, Sw, Swe;
+struct vanGenResult {
+    std::vector<double> h, s_w, s_we;
 };
 
-struct selectSoilType_Result {
-    double wsand, wclay, wsilt, phi, alpha, nvg, theta, Swr;
+struct soilType {
+    double wsand, wclay, wsilt, phi, alpha, nvg, theta, s_wr;
 };
 
-selectSoilType_Result selectSoilType_src(const std::string_view& soiltype);
+soilType selectSoilTypeSrc(const std::string_view& soil_type);
 
-vanGen_Result vanGen_src(const std::vector<double>& z,
-                         const double& WT,
-                         const std::vector<std::string>& soiltypes,
+vanGenResult vanGenSrc(const std::vector<double>& z,
+                         const double& wt,
+                         const std::vector<std::string>& soil_types,
                          const std::vector<double>& thicknesses);


### PR DESCRIPTION
Comments in `./src` were rewritten using the Javadoc convention 
Standartization variables and methods naming 
Fix `README.md` and typos in `MAINSANTILUDO.py` 